### PR TITLE
Fix Display of ADC and IQ rate

### DIFF
--- a/ExtIO_sddc/RadioHandler.cpp
+++ b/ExtIO_sddc/RadioHandler.cpp
@@ -499,8 +499,14 @@ bool RadioHandlerClass::UptRand(bool b)
 
 void* tShowStats(void* args)
 {
+	double count2sec;
 	LARGE_INTEGER EndingTime;
 	//   double timeElapsed = 0;
+
+	LARGE_INTEGER Frequency;
+	QueryPerformanceFrequency(&Frequency);
+	count2sec = 1.0 / Frequency.QuadPart;
+
 	BytesXferred = 0;
 	SamplesXIF = 0;
 	UINT8 cnt = 0;

--- a/ExtIO_sddc/config.cpp
+++ b/ExtIO_sddc/config.cpp
@@ -5,9 +5,7 @@ const char* radioname[4] = { "NORADIO","BBRF103","HF103", "RX888" };
 
 class cglobal global;
 int Xfreq;
-double count2usec;
-double count2msec;
-double count2sec;
+
 char strversion[] = "ExtIO_SDDC.dll v1.01";
 double gdFreqCorr_ppm = FREQCORRECTION;
 double adcfixedfreq = ADC_FREQ;

--- a/ExtIO_sddc/config.h
+++ b/ExtIO_sddc/config.h
@@ -95,9 +95,6 @@ enum rf_mode { HFMODE = 0x1, VLFMODE = 0x2, VHFMODE = 0x3, NOMODE = 4 };
 #define TIMEOUT (2000)
 
 extern double pi;
-extern double count2usec;
-extern double count2msec;
-extern double count2sec;
 extern int Xfreq;
 extern char strversion[];
 extern double gdFreqCorr_ppm;


### PR DESCRIPTION
count2sec is not initialize which cause UI didn't show the ADC rate.

Fix this and also move this to local variable as there is no other usage for count2sec, count2msec and count2usec.