### PR TITLE
Optimize r2iq

### DIFF
--- a/ExtIO_sddc/RadioHandler.cpp
+++ b/ExtIO_sddc/RadioHandler.cpp
@@ -319,9 +319,16 @@ bool RadioHandlerClass::InitBuffers() {
 		DbgPrintf("buffer transferSize = %d. packet size = %ld. packets per transfer = %ld\n"
 			, global.transferSize, pktSize, ppx);
 	}
-	// Allocate all the buffers for the input queues
+	// Allocate one big contitues buffer for all buffers in the input queues
+	// Buffer is formated as the following:
+	// [FFTN_R_ADC] + [FFTN_R_ADC] + [FFTN_R_ADC] + [FFTN_R_ADC] + [FFTN_R_ADC] + ....
+	//                ^                             ^
+	//                buffer[0]                     buffer[1]
+	// use float to grantee the alignment
+	PUCHAR buffer = (PUCHAR)(new float[(FFTN_R_ADC + global.transferSize * QUEUE_SIZE) / sizeof(float) ]);
 	for (int i = 0; i < QUEUE_SIZE; i++) {
-		buffers[i] = new UCHAR[global.transferSize];
+		buffers[i] = buffer + FFTN_R_ADC + global.transferSize * i;
+
 		inOvLap[i].hEvent = CreateEvent(NULL, false, false, NULL);
 	}
 	// Allocate the buffers for the output queue


### PR DESCRIPTION
1. Leverage new execute API in fftw3 to avoid create the sample plans
   for differet input & output.
2. Move per thread data into the structure of r2iqThreadArg. This will
   reduce the caculation of the tight loops.
3. Move read buffer to a continues buffer. Except the last block, all
   other blocks' overlap handling is simplified.