### PR TITLE
Code cleanup for r2iq

### DIFF
--- a/ExtIO_sddc/ExtIO_sddc.cpp
+++ b/ExtIO_sddc/ExtIO_sddc.cpp
@@ -336,7 +336,6 @@ int64_t EXTIO_API SetHWLO64(int64_t LOfreq)
 			ExtIoSetMGC(giMgcIdxVHF);
 			SetAttenuator(giAttIdxVHF);
 			giExtSrateIdxVHF = 2;
-			r2iqCntrl.Setdecimate(giExtSrateIdxVHF);
 			if (pfnCallback) EXTIO_STATUS_CHANGE(pfnCallback, extHw_Changed_SampleRate);
 			if (pfnCallback) EXTIO_STATUS_CHANGE(pfnCallback, extHw_Changed_TUNE);
 			RedrawWindow(h_dialog, NULL, NULL, RDW_INVALIDATE);
@@ -347,7 +346,6 @@ int64_t EXTIO_API SetHWLO64(int64_t LOfreq)
 		{
 		case VHFMODE:
 			RadioHandler.UpdatemodeRF(HFMODE);
-			r2iqCntrl.Setdecimate(giExtSrateIdxHF);
 			ExtIoSetMGC(giMgcIdxHF);
 			SetAttenuator(giAttIdxHF);
 			if (pfnCallback) EXTIO_STATUS_CHANGE(pfnCallback, extHw_Changed_SampleRate);

--- a/ExtIO_sddc/RadioHandler.cpp
+++ b/ExtIO_sddc/RadioHandler.cpp
@@ -50,8 +50,6 @@ void RadioHandlerClass::AdcSamplesProcess()
 	int odx = 0;
 	unsigned int kidx = 0, strd = 0;
 	int rd = r2iqCntrl.getRatio();
-
-	r2iqCntrl.TurnOn(0);  
 	
 	if (EndPt) { // real data
 		long pktSize = EndPt->MaxPktSize;
@@ -296,6 +294,8 @@ bool RadioHandlerClass::Start(int srate_idx)
 		[this](void* arg){
 			this->AdcSamplesProcess();
 		}, nullptr);
+	r2iqCntrl.TurnOn(0);
+
 	return true;
 }
 

--- a/ExtIO_sddc/RadioHandler.cpp
+++ b/ExtIO_sddc/RadioHandler.cpp
@@ -402,7 +402,7 @@ bool RadioHandlerClass::UptRand(bool b)
 		hardware->FX3SetGPIO(RANDO);
 	else
 		hardware->FX3UnsetGPIO(RANDO);
-	r2iqCntrl.randADC = randout;
+	r2iqCntrl.updateRand(randout);
 	return randout;
 }
 

--- a/ExtIO_sddc/r2iq.cpp
+++ b/ExtIO_sddc/r2iq.cpp
@@ -356,7 +356,6 @@ void * r2iqControlClass::r2iqThreadf(r2iqThreadArg *th) {
 
 		ADCSAMPLE *dataADC; // pointer to input data
 		float *inloop;            // pointer to first fft input buffer
-		int midx = this->bufIdx;
 		rf_mode  moderf = RadioHandler.GetmodeRF();
 		dataADC = (ADCSAMPLE *)buffer;
 		int blocks = fftPerBuf;
@@ -522,8 +521,8 @@ void * r2iqControlClass::r2iqThreadf(r2iqThreadArg *th) {
 		}
 		else
 		{      // decimate in frequency plus tuning
-			int modx = midx / mratio;
-			int moff = midx - modx * mratio;
+			int modx = idx / mratio;
+			int moff = idx - modx * mratio;
 			int offset = ((transferSize / 2) / mratio) *moff;
 			pout = (float *)(this->obuffers[modx] + offset);
 

--- a/ExtIO_sddc/r2iq.h
+++ b/ExtIO_sddc/r2iq.h
@@ -18,23 +18,9 @@ public:
     r2iqControlClass();
     ~r2iqControlClass();
 
-    bool r2iqOn;        // r2iq on flag
-    uint8_t** buffers;    // pointer to input buffers
-    float** obuffers;   // pointer to output buffers
-    int bufIdx;         // index to next buffer to be processed
-    int cntr;           // counter of input buffer to be processed
-    int Setdecimate(int dec);
-    bool randADC;       // randomized ADC output
-    long lastThread;    // last thread previous to the current
-    bool Initialized;   // r2iq already initialized
-    bool LWmode;
-
-    bool LWactive() {return LWmode; }
-    int getDecidx() {return mdecimation;}
-    int getFftN()   {return mfftdim [mdecimation];}
-    int getFftN(int x)   {return mfftdim [x];}
     int getRatio()  {return mratio [mdecimation];}
     int getTunebin() {return mtunebin;}
+    void updateRand(bool v) {this->randADC = v; }
     int64_t UptTuneFrq(int64_t freq, int64_t tunefreq);  // Update tunebin and return normalized LO frequency.
     void Updt_SR_LO_TUNE(int srate_idx, int64_t* oldLO, int64_t* oldTune);
 
@@ -45,6 +31,15 @@ public:
     void DataReady(void);
 
 private:
+    bool r2iqOn;        // r2iq on flag
+    uint8_t** buffers;    // pointer to input buffers
+    float** obuffers;   // pointer to output buffers
+    int bufIdx;         // index to next buffer to be processed
+    int cntr;           // counter of input buffer to be processed
+    bool randADC;       // randomized ADC output
+    bool Initialized;   // r2iq already initialized
+    bool LWmode;
+
     float GainScale;
     int mdecimation ;   // selected decimation ratio
                         // 0 => 32Msps, 1=> 16Msps, 2 = 8Msps, 3 = 4Msps, 5 = 2Msps
@@ -60,16 +55,22 @@ private:
     int fftPerBuf; // number of ffts per buffer with 256|768 overlap
     fftwf_complex *pfilterht;       // time filter ht
     fftwf_complex **filterHw;       // Hw complex to each decimation ratio
-    #ifdef _DEBUG
+#ifdef _DEBUG
     fftwf_plan *filterplan_f2t_c2c; // frequency to time fft used for debug
     fftwf_complex **filterHt;       // Ht time vector used for debug
-    #endif
+#endif
 
     uint32_t processor_count;
     r2iqThreadArg* threadArgs[N_R2IQ_THREAD];
     std::condition_variable cvADCbufferAvailable;  // unlock when a sample buffer is ready
     std::mutex mutexR2iqControl;                   // r2iq control lock
     std::thread* r2iq_thread[N_R2IQ_THREAD]; // thread pointers
+
+protected:
+    int Setdecimate(int dec);
+    int getDecidx() {return mdecimation;}
+    int getFftN()   {return mfftdim [mdecimation];}
+    int getFftN(int x)   {return mfftdim [x];}
 
 };
 

--- a/ExtIO_sddc/r2iq.h
+++ b/ExtIO_sddc/r2iq.h
@@ -65,6 +65,7 @@ private:
     fftwf_complex **filterHt;       // Ht time vector used for debug
     #endif
 
+    uint32_t processor_count;
     r2iqThreadArg* threadArgs[N_R2IQ_THREAD];
     std::condition_variable cvADCbufferAvailable;  // unlock when a sample buffer is ready
     std::mutex mutexR2iqControl;                   // r2iq control lock

--- a/ExtIO_sddc/r2iq.h
+++ b/ExtIO_sddc/r2iq.h
@@ -5,6 +5,13 @@
 
 #define NDECIDX 5  //number of srate
 #include "LC_ExtIO_Types.h"
+#include "fftw3.h"
+
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+
+struct r2iqThreadArg;
 
 class r2iqControlClass {
 public:
@@ -12,7 +19,7 @@ public:
     ~r2iqControlClass();
 
     bool r2iqOn;        // r2iq on flag
-    PUCHAR *buffers;    // pointer to input buffers
+    uint8_t** buffers;    // pointer to input buffers
     float** obuffers;   // pointer to output buffers
     int bufIdx;         // index to next buffer to be processed
     int cntr;           // counter of input buffer to be processed
@@ -30,21 +37,41 @@ public:
     int getTunebin() {return mtunebin;}
     int64_t UptTuneFrq(int64_t freq, int64_t tunefreq);  // Update tunebin and return normalized LO frequency.
     void Updt_SR_LO_TUNE(int srate_idx, int64_t* oldLO, int64_t* oldTune);
-    float GainScale;
+
+    void Init(int downsample, float gain, uint8_t** buffers, float** obuffers);
+    void TurnOn(int idx);
+    void TurnOff(void);
+    bool IsOn(void);
+    void DataReady(void);
+
 private:
+    float GainScale;
     int mdecimation ;   // selected decimation ratio
                         // 0 => 32Msps, 1=> 16Msps, 2 = 8Msps, 3 = 4Msps, 5 = 2Msps
     int mfftdim [NDECIDX]; // FFT N dimensions
     int mratio [NDECIDX];  // ratio
     int mtunebin;
 
+    int16_t RandTable[65536];  // ADC RANDomize table used to whitening EMI from ADC data bus.
+
+    void *r2iqThreadf(r2iqThreadArg *th);   // thread function
+
+    int halfFft;    // half the size of the first fft at ADC 64Msps real rate (2048)
+    int fftPerBuf; // number of ffts per buffer with 256|768 overlap
+    fftwf_complex *pfilterht;       // time filter ht
+    fftwf_complex **filterHw;       // Hw complex to each decimation ratio
+    #ifdef _DEBUG
+    fftwf_plan *filterplan_f2t_c2c; // frequency to time fft used for debug
+    fftwf_complex **filterHt;       // Ht time vector used for debug
+    #endif
+
+    r2iqThreadArg* threadArgs[N_R2IQ_THREAD];
+    std::condition_variable cvADCbufferAvailable;  // unlock when a sample buffer is ready
+    std::mutex mutexR2iqControl;                   // r2iq control lock
+    std::thread* r2iq_thread[N_R2IQ_THREAD]; // thread pointers
+
 };
 
 extern class r2iqControlClass r2iqCntrl;
-void initR2iq(int downsample, float gain);
-void r2iqTurnOn(int idx);
-void r2iqTurnOff(void);
-bool r2iqIsOn(void);
-void r2iqDataReady(void);
 
 #endif


### PR DESCRIPTION
1. Move all variables into r2iqcontrol class variables.
2. Make sure r2iq thread exits when starting new threads
3. No need set decimate from extio APIs
4. Fix a race condition
5. Futher reduce the interface of r2iq