### PR TITLE
Cleanup RandioHandler class

### DIFF
--- a/ExtIO_sddc/RadioHandler.h
+++ b/ExtIO_sddc/RadioHandler.h
@@ -54,6 +54,7 @@ public:
 private:
     void AdcSamplesProcess();
     void AbortXferLoop(int qidx);
+    void CaculateStats();
 
     bool dither;
     bool randout;
@@ -64,6 +65,7 @@ private:
     UINT16 firmware;
     rf_mode modeRF;  
 
+    std::condition_variable mutexShowStats;     // unlock to show stats
     RadioHardware* hardware;
 };
 


### PR DESCRIPTION
Reduce global variables.
Prepare to abstract usb transfer logic out of this class.