### PR TITLE
Respect env variable FX3FWROOT

### DIFF
--- a/SDDC_FX3/makefile
+++ b/SDDC_FX3/makefile
@@ -14,8 +14,8 @@
 ## installation root directory path.
 ##
 
-FX3FWROOT=../SDK
-FX3PFWROOT=../SDK/u3p_firmware
+FX3FWROOT?=../SDK
+FX3PFWROOT=$(FX3FWROOT)/u3p_firmware
 
 MODULE = SDDC_FX3
 CYCONFOPT=fx3_release


### PR DESCRIPTION
If SDK is not installed at the default location, you can override it by environment variable.

>FX3FWROOT =../../abc/efg make
or
> export FX3FWROOT=../../abc/efg
> make