### PR TITLE
new makefile for SDDC_FX3 based on FX3 SDK examples from Cypress version 1.3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,21 @@ VS2015: >cmake .. -G "Visual Studio 14 2015 Win32"
 
 ## Build Instructions for firmware
 
-//TODO
+- download latest Cypress EZ-USB FX3 SDK from here: https://www.cypress.com/documentation/software-and-drivers/ez-usb-fx3-software-development-kit
+- follow the installation instructions in the PDF document 'Getting Started with FX3 SDK'; on Windows the default installation path will be 'C:\Program Files (x86)\Cypress\EZ-USB FX3 SDK\1.3' (see pages 17-18) - on Linux the installation path could be something like '/opt/Cypress/cyfx3sdk'
+- add the following environment variables:
+```
+export FX3FWROOT=<installation path>
+export ARMGCC_INSTALL_PATH=<ARM GCC installation path>
+export ARMGCC_VERSION=4.8.1
+```
+(on Linux you may want to add those variables to your '.bash_profile' or '.profile')
+- all the previous steps need to be done only once (or when you want to upgrade the version of the Cypress EZ-USB FX3 SDK)
+- to compile the firmware run:
+```
+cd SDDC_FX3
+make
+```
 
 ## Directory structure:
 

--- a/SDDC_FX3/cyfx_gcc_startup.S
+++ b/SDDC_FX3/cyfx_gcc_startup.S
@@ -1,4 +1,4 @@
-#  Copyright Cypress Semiconductor Corporation, 2010-2011,
+#  Copyright Cypress Semiconductor Corporation, 2010-2018,
 #  All Rights Reserved
 #  UNPUBLISHED, LICENSED SOFTWARE.
 #

--- a/SDDC_FX3/makefile
+++ b/SDDC_FX3/makefile
@@ -66,7 +66,6 @@ clean:
 	rm -f ./$(MODULE).$(EXEEXT)
 	rm -f ./$(MODULE).map
 	rm -f ./*.o
-	rm -f cyfxtx.c cyfx_startup.S cyfx_gcc_startup.S
 
 
 compile: $(C_OBJECT) $(A_OBJECT) $(EXES)

--- a/SDDC_FX3/makefile
+++ b/SDDC_FX3/makefile
@@ -61,16 +61,22 @@ $(C_OBJECT) : %.o : %.c
 $(A_OBJECT) : %.o : %.S
 	$(ASSEMBLE)
 
+ELF2IMG = ./elf2img
+
 clean:
-	rm -f ./$(MODULE).img
 	rm -f ./$(MODULE).$(EXEEXT)
+	rm -f $(ELF2IMG)
+	rm -f ./$(MODULE).img
 	rm -f ./$(MODULE).map
 	rm -f ./*.o
 
 
 compile: $(C_OBJECT) $(A_OBJECT) $(EXES)
 
-$(MODULE).img: $(EXES)
-	$(FX3FWROOT)/util/elf2img/elf2img -i $< -o $@ -v
+$(ELF2IMG) : $(FX3FWROOT)/util/elf2img/elf2img.c
+	gcc -O -Wall -o $@ $<
+
+$(MODULE).img: $(EXES) $(ELF2IMG)
+	$(ELF2IMG) -i $< -o $@ -v
 
 #[]#

--- a/SDDC_FX3/makefile
+++ b/SDDC_FX3/makefile
@@ -1,4 +1,4 @@
-## Copyright Cypress Semiconductor Corporation, 2010-2011,
+## Copyright Cypress Semiconductor Corporation, 2010-2018,
 ## All Rights Reserved
 ## UNPUBLISHED, LICENSED SOFTWARE.
 ##
@@ -15,29 +15,37 @@
 ##
 
 FX3FWROOT?=../SDK
-FX3PFWROOT=$(FX3FWROOT)/u3p_firmware
+CYCONFOPT = fx3_release
+
+#all:compile
+
+include $(FX3FWROOT)/fw_build/fx3_fw/fx3_build_config.mak
 
 MODULE = SDDC_FX3
-CYCONFOPT=fx3_release
 
-all:compile $(MODULE).img
+all:$(MODULE).img
 
-include $(FX3FWROOT)/common/fx3_build_config.mak
+SOURCE= cyfxtx.c		\
+	DebugConsole.c		\
+	i2cmodule.c		\
+	tuner_r82xx.c		\
+	RunApplication.c	\
+	Si5351.c		\
+	StartStopApplication.c	\
+	StartUP.c		\
+	Support.c		\
+	USBdescriptor.c		\
+	USBhandler.c		\
+	hf103.c			\
+	bbrf103.c		\
+	rx888.c			\
+	rx888r2.c
 
-SOURCE +=  DebugConsole.c \
-			i2cmodule.c \
-			tuner_r82xx.c \
-			RunApplication.c \
-			Si5351.c \
-			StartStopApplication.c \
-			StartUP.c \
-			Support.c \
-			USBdescriptor.c \
-			USBhandler.c \
-			hf103.c \
-			bbrf103.c \
-			rx888.c \
-			rx888r2.c
+ifeq ($(CYFXBUILD),arm)
+SOURCE_ASM=cyfx_startup.S
+else
+SOURCE_ASM=cyfx_gcc_startup.S
+endif
 
 C_OBJECT=$(SOURCE:%.c=./%.o)
 A_OBJECT=$(SOURCE_ASM:%.S=./%.o)
@@ -47,25 +55,32 @@ EXES = $(MODULE).$(EXEEXT)
 $(MODULE).$(EXEEXT): $(A_OBJECT) $(C_OBJECT)
 	$(LINK)
 
+cyfxtx.c:
+	cp $(FX3FWROOT)/fw_build/fx3_fw/cyfxtx.c .
+
+cyfx_startup.S:
+	cp $(FX3FWROOT)/fw_build/fx3_fw/cyfx_startup.S .
+
+cyfx_gcc_startup.S:
+	cp $(FX3FWROOT)/fw_build/fx3_fw/cyfx_gcc_startup.S .
+
 $(C_OBJECT) : %.o : %.c
 	$(COMPILE)
 
 $(A_OBJECT) : %.o : %.S
 	$(ASSEMBLE)
 
-./elf2img : $(FX3FWROOT)/util/elf2img.c
-	gcc -o elf2img $<
-
 clean:
-	rm -f ./$(MODULE).$(EXEEXT)
-	rm -f ./elf2img
 	rm -f ./$(MODULE).img
+	rm -f ./$(MODULE).$(EXEEXT)
 	rm -f ./$(MODULE).map
 	rm -f ./*.o
+	rm -f cyfxtx.c cyfx_startup.S cyfx_gcc_startup.S
+
 
 compile: $(C_OBJECT) $(A_OBJECT) $(EXES)
 
-$(MODULE).img : $(MODULE).$(EXEEXT) ./elf2img
-	./elf2img -i $< -o $@
+$(MODULE).img: $(EXES)
+	$(FX3FWROOT)/util/elf2img/elf2img -i $< -o $@ -v
 
 #[]#

--- a/SDDC_FX3/makefile
+++ b/SDDC_FX3/makefile
@@ -55,15 +55,6 @@ EXES = $(MODULE).$(EXEEXT)
 $(MODULE).$(EXEEXT): $(A_OBJECT) $(C_OBJECT)
 	$(LINK)
 
-cyfxtx.c:
-	cp $(FX3FWROOT)/fw_build/fx3_fw/cyfxtx.c .
-
-cyfx_startup.S:
-	cp $(FX3FWROOT)/fw_build/fx3_fw/cyfx_startup.S .
-
-cyfx_gcc_startup.S:
-	cp $(FX3FWROOT)/fw_build/fx3_fw/cyfx_gcc_startup.S .
-
 $(C_OBJECT) : %.o : %.c
 	$(COMPILE)
 


### PR DESCRIPTION
Howard, Oscar,
I just created a new makefile for the SDDC_FX3 firmware based on the EZ-USB FX3 SDK examples from Cypress version 1.3.4.

I ran it and it built the SDDC_FX3.img image file without errors here on Linux; please give it a try and let me know what you think.

Franco
