### PR TITLE
Fix logic in r2iq when dec != 0

### DIFF
--- a/ExtIO_sddc/r2iq.cpp
+++ b/ExtIO_sddc/r2iq.cpp
@@ -357,8 +357,7 @@ void * r2iqControlClass::r2iqThreadf(r2iqThreadArg *th) {
 			for (int m = 0; m < mfft / 2; m++) // circular shift tune fs/2 half array
 			{
 				int mm = _mtunebin + m;
-				if ((_mtunebin + m) > mfft-1)
-					mm -=  mfft;
+				if (mm > halfFft -1) mm -= halfFft;
 
 				th->inFreqTmp[m][0] = (th->ADCinFreq[mm][0] * filter[m][0] +
 					th->ADCinFreq[mm][1] * filter[m][1]);
@@ -371,8 +370,7 @@ void * r2iqControlClass::r2iqThreadf(r2iqThreadArg *th) {
 			{
 				int fm = halfFft - mfft / 2 + m;
 				int mm = _mtunebin - mfft / 2 + m;
-				if (mm < 0)
-					mm += mfft;
+				if (mm < 0) mm += halfFft;
 
 				th->inFreqTmp[mfft / 2 + m][0] = (th->ADCinFreq[mm][0] * filter[fm][0] +
 					th->ADCinFreq[mm][1] * filter[fm][1]);


### PR DESCRIPTION
halffft is the circular shift of the input not mfft.
? It solves tuning problem with all SR and VHF.