### PR TITLE
Move ADC_RATE to radio hardware

### DIFF
--- a/ExtIO_sddc/ExtIO_sddc.cpp
+++ b/ExtIO_sddc/ExtIO_sddc.cpp
@@ -51,20 +51,6 @@ SplashWindow  splashW;
 
 #define IDD_SDDC_SETTINGS	100
 
-void ADCFrequencyCorrection()
-{
-	switch (RadioHandler.getModel())
-	{
-	case HF103:
-		adcfixedfreq = (double)ADC_FREQ * (1.0 + (gdFreqCorr_ppm * 0.000001));
-		break;
-	default: //BBRF103, RX888...  exact frequency, tuning made with Si5351a
-		adcfixedfreq = (double)ADC_FREQ; 
-		break;
-	}
-}
-
-
 //---------------------------------------------------------------------------
 
 HMODULE hInst;
@@ -133,8 +119,6 @@ bool __declspec(dllexport) __stdcall InitHW(char *name, char *model, int& type)
 
 		fftwf_import_wisdom_from_filename("wisdom");
 
-		ADCFrequencyCorrection();
-
 		DbgPrintf((char*)"Init values \n");
 		DbgPrintf("SDR_settings_valid = %d \n", SDR_settings_valid);  // settings are version specific !
 		DbgPrintf("giExtSrateIdxHF = %d   %f Msps \n", giExtSrateIdxHF, pow(2.0, 1.0 + giExtSrateIdxHF));
@@ -147,8 +131,8 @@ bool __declspec(dllexport) __stdcall InitHW(char *name, char *model, int& type)
 		DbgPrintf("glTunefreq = %ld \n", (long int)glTunefreq);
 		DbgPrintf("______________________________________\n");
 		DbgPrintf("freqcorrection = %f \n", gdFreqCorr_ppm);
-		DbgPrintf("adcfixedfreq = %ld \n", (long int)adcfixedfreq);
-		DbgPrintf("adcfixedfr/4 = %ld \n", (long int)(adcfixedfreq / 4.0));
+		DbgPrintf("adcfixedfreq = %ld \n", (long int)RadioHandler.getSampleRate());
+		DbgPrintf("adcfixedfr/4 = %ld \n", (long int)(RadioHandler.getSampleRate() / 4.0));
 		DbgPrintf("______________________________________\n");
 	}
 	return gbInitHW;
@@ -613,9 +597,9 @@ int EXTIO_API ExtIoGetSrates(int srate_idx, double * samplerate)
 	case 4:		div = 2.0;	break;
 	default:    return -1;
 	}
-	*samplerate = (double)((UINT32)((adcfixedfreq / div)));
+	*samplerate = (double)((UINT32)((RadioHandler.getSampleRate() / div)));
      DbgPrintf("*ExtIoGetSrate idx %d  %e\n", srate_idx, *samplerate);
-	return 0;	
+	return 0;
 }
 
 extern "C"

--- a/ExtIO_sddc/RadioHandler.cpp
+++ b/ExtIO_sddc/RadioHandler.cpp
@@ -128,7 +128,7 @@ void RadioHandlerClass::AdcSamplesProcess()
 				saveADCsamplesflag = false; // do it once
 				short* pi = (short*)&buffers[idx][0];
 				unsigned int numsamples = transferSize / sizeof(short);
-				float samplerate  = (float) adcfixedfreq;
+				float samplerate  = (float) getSampleRate();
 				PScopeShot("ADCrealsamples.adc", "ExtIO_sddc.dll",
 					"ADCrealsamples.adc input real ADC 16 bit samples",
 					pi, samplerate, numsamples);
@@ -366,7 +366,7 @@ uint64_t RadioHandlerClass::TuneLO(uint64_t wishedFreq)
 	actLo = hardware->TuneLo(wishedFreq);
 
 	// we need shift the samples
-	float fc = r2iqCntrl.setFreqOffset((wishedFreq - actLo) / (ADC_FREQ / 2.0f));
+	float fc = r2iqCntrl.setFreqOffset((wishedFreq - actLo) / (getSampleRate() / 2.0f));
 
 	if (this->fc != fc)
 	{
@@ -419,7 +419,7 @@ void RadioHandlerClass::CaculateStats()
 
 		duration<double,std::ratio<1,1>> timeElapsed(EndingTime-StartingTime);
 
-		double mBps = (double)kbRead / timeElapsed.count() / 1000;
+		double mBps = (double)kbRead / timeElapsed.count() / 1000 / sizeof(int16_t);
 		double mSpsIF = (double)kSReadIF / timeElapsed.count() / 1000;
 
 		BytesXferred = 0;
@@ -451,3 +451,7 @@ void RadioHandlerClass::UpdBiasT_VHF(bool flag)
 		hardware->FX3UnsetGPIO(BIAS_VHF);
 }
 
+uint32_t RadioHandlerClass::getSampleRate()
+{
+	return hardware->getSampleRate();
+}

--- a/ExtIO_sddc/RadioHandler.h
+++ b/ExtIO_sddc/RadioHandler.h
@@ -40,6 +40,8 @@ public:
     bool GetADCsamples() { return  samplesADCflag; }
     UINT16 GetFirmware() { return firmware; }
 
+    uint32_t getSampleRate();
+
     const char* getName();
     RadioModel getModel() { return radio; }
 
@@ -100,6 +102,8 @@ public:
 
     bool FX3producerOn() { return Fx3->Control(STARTFX3); }
     bool FX3producerOff() { return Fx3->Control(STOPFX3); }
+
+    virtual uint32_t getSampleRate();
 
     bool FX3SetGPIO(uint32_t mask);
     bool FX3UnsetGPIO(uint32_t mask);

--- a/ExtIO_sddc/config.cpp
+++ b/ExtIO_sddc/config.cpp
@@ -4,7 +4,6 @@
 int Xfreq = 10000;
 char strversion[] = "ExtIO_SDDC.dll v1.01";
 double gdFreqCorr_ppm = FREQCORRECTION;
-double adcfixedfreq = ADC_FREQ;
 double gdGainCorr_dB = GAIN_ADJ;            // in dB
 bool saveADCsamplesflag = false;
 bool run = false;

--- a/ExtIO_sddc/config.h
+++ b/ExtIO_sddc/config.h
@@ -49,11 +49,6 @@ inline void null_func(const char *format, ...) { }
 
 #define	QUEUE_SIZE 64
 
-#ifndef ADC_FREQ
-#define ADC_FREQ  (64000000)	// ADC sampling frequency
-#endif
-
-#define HF_UPPER  (ADC_FREQ/2)	   
 #define FREQCORRECTION (0.0)   // Default xtal frequency correction in ppm
 #define GAIN_ADJ (0.0)          // default gain factor in DB
 
@@ -66,8 +61,8 @@ inline void null_func(const char *format, ...) { }
 
 enum rf_mode { NOMODE = 0, HFMODE = 0x1, VHFMODE = 0x2 }; 
 
-#define HF_HIGH (ADC_FREQ/2)    // 32M
-#define MW_HIGH (2000000)
+#define HF_HIGH (32000000)    // 32M
+#define MW_HIGH ( 2000000)
 
 #ifdef OFFSET_BINARY
 #define ADCSAMPLE UINT16
@@ -94,7 +89,6 @@ extern double pi;
 extern int Xfreq;
 extern char strversion[];
 extern double gdFreqCorr_ppm;
-extern double adcfixedfreq;
 extern double gdGainCorr_dB;
 extern bool saveADCsamplesflag;
 

--- a/ExtIO_sddc/radio/BBRF103Radio.cpp
+++ b/ExtIO_sddc/radio/BBRF103Radio.cpp
@@ -26,7 +26,7 @@ BBRF103Radio::BBRF103Radio(fx3class* fx3)
 
 void BBRF103Radio::Initialize()
 {
-    uint32_t data = (UINT32)CORRECT(ADC_FREQ);
+    uint32_t data = getSampleRate();
     Fx3->Control(STARTADC, data);
 }
 

--- a/ExtIO_sddc/radio/BBRF103Radio.cpp
+++ b/ExtIO_sddc/radio/BBRF103Radio.cpp
@@ -26,7 +26,7 @@ BBRF103Radio::BBRF103Radio(fx3class* fx3)
 
 void BBRF103Radio::Initialize()
 {
-    uint32_t data = getSampleRate();
+    uint32_t data =  (uint32_t)CORRECT(getSampleRate());
     Fx3->Control(STARTADC, data);
 }
 

--- a/ExtIO_sddc/radio/RX888R2Radio.cpp
+++ b/ExtIO_sddc/radio/RX888R2Radio.cpp
@@ -46,7 +46,7 @@ RX888R2Radio::RX888R2Radio(fx3class *fx3)
 
 void RX888R2Radio::Initialize()
 {
-    uint32_t data = (UINT32)CORRECT(ADC_FREQ);
+    uint32_t data = getSampleRate();
     Fx3->Control(STARTADC, data);
 }
 

--- a/ExtIO_sddc/radio/RX888R2Radio.cpp
+++ b/ExtIO_sddc/radio/RX888R2Radio.cpp
@@ -46,7 +46,7 @@ RX888R2Radio::RX888R2Radio(fx3class *fx3)
 
 void RX888R2Radio::Initialize()
 {
-    uint32_t data = getSampleRate();
+    uint32_t data =  (uint32_t)CORRECT(getSampleRate());
     Fx3->Control(STARTADC, data);
 }
 

--- a/ExtIO_sddc/radio/RadioHardware.cpp
+++ b/ExtIO_sddc/radio/RadioHardware.cpp
@@ -29,5 +29,5 @@ RadioHardware::~RadioHardware()
 
 uint32_t RadioHardware::getSampleRate()
 {
-    return (uint32_t)CORRECT(DEFAULT_ADC_FREQ);
+    return DEFAULT_ADC_FREQ;
 }

--- a/ExtIO_sddc/radio/RadioHardware.cpp
+++ b/ExtIO_sddc/radio/RadioHardware.cpp
@@ -1,5 +1,7 @@
 #include "RadioHandler.h"
 
+#define DEFAULT_ADC_FREQ  (64000000)	// ADC sampling frequency
+
 bool RadioHardware::FX3SetGPIO(uint32_t mask)
 {
     gpios |= mask;
@@ -23,4 +25,9 @@ RadioHardware::~RadioHardware()
 
         delete Fx3;
     }
+}
+
+uint32_t RadioHardware::getSampleRate()
+{
+    return (uint32_t)CORRECT(DEFAULT_ADC_FREQ);
 }

--- a/ExtIO_sddc/tdialog.cpp
+++ b/ExtIO_sddc/tdialog.cpp
@@ -84,9 +84,9 @@ BOOL CALLBACK DlgMainFn(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 		if (cntime-- <= 0)
 		{
 			cntime = 5;
-			sprintf(lbuffer, "%2.9f Msps",  adcfixedfreq / 1000000);
+			sprintf(lbuffer, "%2.9f Msps",  RadioHandler.getSampleRate() / 1000000.0f);
 			SetWindowText(GetDlgItem(hWnd, IDC_STATIC13), lbuffer);
-			sprintf(lbuffer, "%6.3f Msps measured", g_Bps * adcfixedfreq / ((double)ADC_FREQ*2.0) );
+			sprintf(lbuffer, "%6.3f Msps measured", g_Bps );
 			SetWindowText(GetDlgItem(hWnd, IDC_STATIC14), lbuffer);
 			sprintf(lbuffer, "%6.3f Msps measured", g_SpsIF);
 			SetWindowText(GetDlgItem(hWnd, IDC_STATIC16), lbuffer);


### PR DESCRIPTION
ADC_RATE is no more a global variable, which enable us
the next step to make it configurable.