### PR TITLE
Make sure we display sample rate as the uncorrected value

### DIFF
--- a/ExtIO_sddc/ExtIO_sddc.cpp
+++ b/ExtIO_sddc/ExtIO_sddc.cpp
@@ -579,17 +579,10 @@ extern "C"
 int EXTIO_API ExtIoGetSrates(int srate_idx, double * samplerate)
 {
 	EnterFunction1(srate_idx);
-	double div;
-	switch (srate_idx)
-	{
-	case 0:		div = 32.0;	break;
-	case 1:		div = 16.0;	break;
-	case 2:		div = 8.0;	break;
-	case 3:		div = 4.0;	break;
-	case 4:		div = 2.0;	break;
-	default:    return -1;
-	}
-	*samplerate = (double)((UINT32)((RadioHandler.getSampleRate() / div)));
+	double div = pow(2.0, srate_idx);
+	*samplerate = 1000000.0 * (div * 2);
+	if (*samplerate / RadioHandler.getSampleRate() * 2.0 > 1.1)
+		return -1;
      DbgPrintf("*ExtIoGetSrate idx %d  %e\n", srate_idx, *samplerate);
 	return 0;
 }
@@ -617,8 +610,6 @@ int  EXTIO_API ExtIoSetSrate(int srate_idx)
 		else
 			giExtSrateIdxHF = srate_idx;
 
-		EXTIO_STATUS_CHANGE(pfnCallback, extHw_Changed_LO);
-		EXTIO_STATUS_CHANGE(pfnCallback, extHw_Changed_TUNE);
 		EXTIO_STATUS_CHANGE(pfnCallback, extHw_Changed_SampleRate);
 
 		return 0;

--- a/ExtIO_sddc/RadioHandler.cpp
+++ b/ExtIO_sddc/RadioHandler.cpp
@@ -275,6 +275,10 @@ bool RadioHandlerClass::Init(HMODULE hInst)
 bool RadioHandlerClass::Start(int srate_idx)
 {
 	Stop();
+	double div = pow(2.0, srate_idx);
+	auto samplerate = 1000000.0 * (div * 2);
+	int decimate = (int)log2(RadioHandler.getSampleRate() / (2 * samplerate));
+
 	DbgPrintf("RadioHandlerClass::Start\n");
 	kbRead = 0; // zeros the kilobytes counter
 	kSReadIF = 0;
@@ -286,7 +290,7 @@ bool RadioHandlerClass::Start(int srate_idx)
 		this->CaculateStats();
 	}, nullptr);
 	// 0,1,2,3,4 => 32,16,8,4,2 MHz
-	r2iqCntrl.Init( 4 - srate_idx, hardware->getGain(), buffers, obuffers);
+	r2iqCntrl.Init( decimate, hardware->getGain(), buffers, obuffers);
 	adc_samples_thread = new std::thread(
 		[this](void* arg){
 			this->AdcSamplesProcess();

--- a/ExtIO_sddc/radio/BBRF103Radio.cpp
+++ b/ExtIO_sddc/radio/BBRF103Radio.cpp
@@ -26,7 +26,7 @@ BBRF103Radio::BBRF103Radio(fx3class* fx3)
 
 void BBRF103Radio::Initialize()
 {
-    uint32_t data =  (uint32_t)CORRECT(getSampleRate());
+    uint32_t data =  getSampleRate();
     Fx3->Control(STARTADC, data);
 }
 

--- a/ExtIO_sddc/radio/RX888R2Radio.cpp
+++ b/ExtIO_sddc/radio/RX888R2Radio.cpp
@@ -46,7 +46,7 @@ RX888R2Radio::RX888R2Radio(fx3class *fx3)
 
 void RX888R2Radio::Initialize()
 {
-    uint32_t data =  (uint32_t)CORRECT(getSampleRate());
+    uint32_t data =  getSampleRate();
     Fx3->Control(STARTADC, data);
 }
 

--- a/ExtIO_sddc/radio/RadioHardware.cpp
+++ b/ExtIO_sddc/radio/RadioHardware.cpp
@@ -29,5 +29,5 @@ RadioHardware::~RadioHardware()
 
 uint32_t RadioHardware::getSampleRate()
 {
-    return DEFAULT_ADC_FREQ;
+    return (uint32_t)CORRECT(DEFAULT_ADC_FREQ);
 }


### PR DESCRIPTION
1. Change samplerate to the uncorrected number
2. Samplerate index is indepdent of ADC frequency.
3. Give all sample rate above 2M to samplerate / 2.