### PR TITLE
Fix two issues

### DIFF
--- a/ExtIO_sddc/RadioHandler.cpp
+++ b/ExtIO_sddc/RadioHandler.cpp
@@ -282,11 +282,11 @@ bool RadioHandlerClass::Start(int srate_idx)
 	}, nullptr);
 	// 0,1,2,3,4 => 32,16,8,4,2 MHz
 	r2iqCntrl.Init( decimate, hardware->getGain(), buffers, obuffers);
+	r2iqCntrl.TurnOn(0);
 	adc_samples_thread = new std::thread(
 		[this](void* arg){
 			this->AdcSamplesProcess();
 		}, nullptr);
-	r2iqCntrl.TurnOn(0);
 
 	return true;
 }

--- a/ExtIO_sddc/r2iq.cpp
+++ b/ExtIO_sddc/r2iq.cpp
@@ -37,10 +37,7 @@ struct r2iqThreadArg {
 };
 
 r2iqControlClass::r2iqControlClass()
-	
 {
-	bufIdx = 0;
-	cntr = 0;
 	r2iqOn = false;
 	Initialized = false;
 	randADC = false;
@@ -74,7 +71,10 @@ float r2iqControlClass::setFreqOffset(float offset)
 }
 
 void r2iqControlClass::TurnOn(int idx) {
+	this->bufIdx = 0;
+	this->cntr = 0;
 	this->r2iqOn = true;
+
 	for (unsigned t = 0; t < processor_count; t++) {
 		r2iq_thread[t] = new std::thread(
 			[this] (void* arg)
@@ -274,7 +274,6 @@ void * r2iqControlClass::r2iqThreadf(r2iqThreadArg *th) {
 			pout = (float *)(this->obuffers[modx] + offset);
 
 		}
-
 
 		ADCSAMPLE *dataADC; // pointer to input data
 		float *inloop;            // pointer to first fft input buffer


### PR DESCRIPTION
1. Start r2iq thread before adc thread. So bufidx will be zero when ADC
   receives the first packet.
2. Always reset bufidx and cntr before start r2iq thread.