### PR TITLE
Fix the phase noise

### DIFF
--- a/ExtIO_sddc/RadioHandler.cpp
+++ b/ExtIO_sddc/RadioHandler.cpp
@@ -80,7 +80,7 @@ void RadioHandlerClass::AdcSamplesProcess()
 			// submit result to SDR application before processing next packet
 			if (run &&						// app is running
 				count >= QUEUE_SIZE &&		// skip first batch
-				((idx + 1) % rd == 0))		// if decimate, every *rd* packages
+				(idx % rd == 0))		// if decimate, every *rd* packages
 			{
 				int oidx = idx / rd;
 				std::unique_lock<std::mutex> lk(fc_mutex);

--- a/ExtIO_sddc/RadioHandler.cpp
+++ b/ExtIO_sddc/RadioHandler.cpp
@@ -161,15 +161,8 @@ RadioHandlerClass::RadioHandlerClass() :
 	contexts = new PUCHAR[QUEUE_SIZE];
 	obuffers = new float* [QUEUE_SIZE];
 
-	// Allocate one big contitues buffer for all buffers in the input queues
-	// Buffer is formated as the following:
-	// [FFTN_R_ADC] + [FFTN_R_ADC] + [FFTN_R_ADC] + [FFTN_R_ADC] + [FFTN_R_ADC] + ....
-	//                ^                             ^
-	//                buffer[0]                     buffer[1]
-	// use float to grantee the alignment
-	PUCHAR buffer = (PUCHAR)(new float[(FFTN_R_ADC + transferSize * QUEUE_SIZE) / sizeof(float) ]);
 	for (int i = 0; i < QUEUE_SIZE; i++) {
-		buffers[i] = buffer + FFTN_R_ADC + transferSize * i;
+		buffers[i] = (PUCHAR)new uint16_t[transferSize / sizeof(uint16_t)];
 
 		inOvLap[i].hEvent = CreateEvent(NULL, false, false, NULL);
 
@@ -183,9 +176,8 @@ RadioHandlerClass::~RadioHandlerClass()
 	for (int n = 0; n < QUEUE_SIZE; n++) {
 		CloseHandle(inOvLap[n].hEvent);
 		delete[] obuffers[n];
+		delete[] buffers[n];
 	}
-
-	delete[] (buffers[0] - FFTN_R_ADC);
 
 	delete[] buffers;
 	delete[] obuffers;

--- a/ExtIO_sddc/r2iq.cpp
+++ b/ExtIO_sddc/r2iq.cpp
@@ -267,13 +267,13 @@ void * r2iqControlClass::r2iqThreadf(r2iqThreadArg *th) {
 			buffer = (char *)this->buffers[this->bufIdx];
 			idx = this->bufIdx;
 
-			this->bufIdx = ((this->bufIdx + 1) % QUEUE_SIZE);
-			this->cntr--;
-
 			int modx = this->bufIdx / mratio;
 			int moff = this->bufIdx - modx * mratio;
 			int offset = ((transferSize / 2) / mratio) *moff;
 			pout = (float *)(this->obuffers[modx] + offset);
+
+			this->bufIdx = ((this->bufIdx + 1) % QUEUE_SIZE);
+			this->cntr--;
 
 			endloop = lastThread->ADCinTime[fftPerBuf - 1] + halfFft;
 			lastThread = th;

--- a/ExtIO_sddc/r2iq.h
+++ b/ExtIO_sddc/r2iq.h
@@ -37,6 +37,7 @@ private:
     int cntr;           // counter of input buffer to be processed
     bool randADC;       // randomized ADC output
     bool Initialized;   // r2iq already initialized
+    r2iqThreadArg* lastThread;
 
     float GainScale;
     int mdecimation ;   // selected decimation ratio


### PR DESCRIPTION
There are 3 problems:
1. The new approach to get overlap data does not work. It may get stale data.
2. The logic to calculate output buffer index when decimated is wrong. We should use index instead of index +1
3. We can remove negative bands.