### PR TITLE
Fix hang when switch freq

### DIFF
--- a/ExtIO_sddc/RadioHandler.cpp
+++ b/ExtIO_sddc/RadioHandler.cpp
@@ -268,13 +268,19 @@ bool RadioHandlerClass::Start(int srate_idx)
 
 bool RadioHandlerClass::Stop()
 {
+	std::unique_lock<std::mutex> lk(stop_mutex);
 	DbgPrintf("RadioHandlerClass::Stop %d\n", run);
 	if (run)
 	{
 		run = false; // now waits for threads
 		show_stats_thread->join(); //first to be joined
+		delete show_stats_thread;
+		show_stats_thread = nullptr;
 		DbgPrintf("show_stats_thread join2\n");
+
 		adc_samples_thread->join();
+		delete adc_samples_thread;
+		adc_samples_thread = nullptr;
 		DbgPrintf("adc_samples_thread join1\n");
 	}
 	return true;

--- a/ExtIO_sddc/RadioHandler.h
+++ b/ExtIO_sddc/RadioHandler.h
@@ -77,6 +77,7 @@ private:
     RadioHardware* hardware;
 
     std::mutex fc_mutex;
+    std::mutex stop_mutex;
     float fc;
     shift_limited_unroll_C_sse_data_t stateFineTune;
 };


### PR DESCRIPTION
Only allow one thread to stop the USB reading thread to avoid the race
condition.