### PR TITLE
use atomic instead of mutex during DataReady

### DIFF
--- a/ExtIO_sddc/r2iq.cpp
+++ b/ExtIO_sddc/r2iq.cpp
@@ -96,13 +96,11 @@ bool r2iqControlClass::IsOn(void) { return(this->r2iqOn); }
 
 void r2iqControlClass::DataReady()
 { // signals new sample buffer arrived
-	int pending;
 	if (!this->r2iqOn)
 		return;
-	mutexR2iqControl.lock();
-	pending = this->cntr;
-	this->cntr++;
-	mutexR2iqControl.unlock();
+
+	auto pending = std::atomic_fetch_add(&this->cntr, 1);
+
 	if (pending == 0)
 		cvADCbufferAvailable.notify_one(); // signal data available
 	else
@@ -227,23 +225,21 @@ void r2iqControlClass::Init(float gain, uint8_t **buffers, float** obuffers)
 
 void * r2iqControlClass::r2iqThreadf(r2iqThreadArg *th) {
 
-	char *buffer;
-	int lastdecimate = -1;
-
-	float * pout;
+	int mfft = this->getFftN();
+	int mratio = this->getRatio();
 	int decimate = this->getDecimate();
 	fftwf_complex* filter = filterHw[decimate];
+	rf_mode moderf = RadioHandler.GetmodeRF();
 	th->plan_f2t_c2c = th->plans_f2t_c2c[decimate];
 
 	while (r2iqOn) {
-		int mfft = this->getFftN();
-		int mratio = this->getRatio();
-		int idx;
+		ADCSAMPLE *dataADC; // pointer to input data
+		float *endloop;           // pointer to end data to be copied to beginning
+		float * pout;
+
 		float iscale = this->GainScale * (float)powf(10.0f, gdGainCorr_dB / 20.0f);
 		float qscale;
 		int _mtunebin = this->mtunebin;  // Update LO tune is possible during run
-		rf_mode  moderf = RadioHandler.GetmodeRF();
-		float *endloop;           // pointer to end data to be copied to beginning
 
 		// TODO: Change this to sideband check
 		if (moderf == VHFMODE) {
@@ -261,8 +257,7 @@ void * r2iqControlClass::r2iqThreadf(r2iqThreadArg *th) {
 			std::unique_lock<std::mutex> lk(mutexR2iqControl);
 			while (this->cntr <= 0)
 			{
-				cvADCbufferAvailable.wait(lk, [&wakecnt, this]
-				{
+				cvADCbufferAvailable.wait(lk, [&wakecnt, this] {
 					wakecnt++;
 					return this->cntr > 0;
 				});
@@ -271,14 +266,13 @@ void * r2iqControlClass::r2iqThreadf(r2iqThreadArg *th) {
 			if (!r2iqOn)
 				return 0;
 
-			buffer = (char *)this->buffers[this->bufIdx];
-			idx = this->bufIdx;
-			this->cntr--;
+			dataADC = (ADCSAMPLE *)this->buffers[this->bufIdx];
+			std::atomic_fetch_sub(&this->cntr, 1);
 
 			int modx = this->bufIdx / mratio;
 			int moff = this->bufIdx - modx * mratio;
-			int offset = ((transferSize / 2) / mratio) *moff;
-			pout = (float *)(this->obuffers[modx] + offset);
+			int offset = ((transferSize / sizeof(ADCSAMPLE)) / mratio) * moff;
+			pout = this->obuffers[modx] + offset;
 
 			this->bufIdx = ((this->bufIdx + 1) % QUEUE_SIZE);
 	
@@ -286,13 +280,8 @@ void * r2iqControlClass::r2iqThreadf(r2iqThreadArg *th) {
 			lastThread = th;
 		}
 
-		ADCSAMPLE *dataADC; // pointer to input data
-		float *inloop;            // pointer to first fft input buffer
-		dataADC = (ADCSAMPLE *)buffer;
-		int blocks = fftPerBuf;
-
 		// first frame
-		inloop = th->ADCinTime[0];
+		auto inloop = th->ADCinTime[0];
 		for (int m = 0; m < halfFft; m++) {
 			*inloop++ = *endloop++;   // duplicate form last frame halfFft samples
 		}

--- a/ExtIO_sddc/r2iq.h
+++ b/ExtIO_sddc/r2iq.h
@@ -10,6 +10,7 @@
 #include <thread>
 #include <mutex>
 #include <condition_variable>
+#include <atomic>
 
 struct r2iqThreadArg;
 
@@ -35,7 +36,7 @@ private:
     uint8_t** buffers;    // pointer to input buffers
     float** obuffers;   // pointer to output buffers
     int bufIdx;         // index to next buffer to be processed
-    int cntr;           // counter of input buffer to be processed
+    volatile std::atomic<int> cntr;           // counter of input buffer to be processed
     bool randADC;       // randomized ADC output
     r2iqThreadArg* lastThread;
 


### PR DESCRIPTION
This helps USB reading thread keep up with the line speed. As USB reading thread will not be blocked by r2iq thread.