### PR TITLE
Optimize r2iqThreadf function

### DIFF
--- a/ExtIO_sddc/FX3handler.h
+++ b/ExtIO_sddc/FX3handler.h
@@ -46,7 +46,7 @@ public:
 
 	bool SendI2cbytes(UINT8 i2caddr, UINT8 regaddr, PUINT8 pdata, UINT8 len);
 	bool ReadI2cbytes(UINT8 i2caddr, UINT8 regaddr, PUINT8 pdata, UINT8 len);
-	
+
 private:
 	CCyFX3Device* fx3dev;
 	bool GetFx3Device();


### PR DESCRIPTION
Use one array to store the float samples. And move to 3/4 of one window.

This reduce the CPU consumption of this function from 10% of whole program to 2%.