### PR TITLE
Have different  queue size  and concurrent usb read

### DIFF
--- a/ExtIO_sddc/RadioHandler.h
+++ b/ExtIO_sddc/RadioHandler.h
@@ -61,8 +61,10 @@ private:
     void AdcSamplesProcess();
     void AbortXferLoop(int qidx);
     void CaculateStats();
+    void OnDataPacket(int idx);
 
     bool run;
+    unsigned long count;    // absolute index
 
     bool dither;
     bool randout;


### PR DESCRIPTION
Define a new constant USB_READ_CONCURRENT to define the concurrent USB reads. It is different than the queue size.