### PR TITLE
Avoid memory allocation/free at the critial path

### DIFF
--- a/Core/arch/win32/CyAPI/CyAPI.cpp
+++ b/Core/arch/win32/CyAPI/CyAPI.cpp
@@ -2043,7 +2043,7 @@ bool CCyUSBEndPoint::FinishDataXfer(PUCHAR buf, LONG &bufLen, OVERLAPPED *ov, PU
         memcpy(pktInfos, pktPtr, pTransfer->IsoPacketLength);
     }
 
-    delete[] pXmitBuf;     // [] Changed in 1.5.1.3
+//    delete[] pXmitBuf;     // [] Changed in 1.5.1.3
 
     return rResult && (UsbdStatus == 0) && (NtStatus == 0);
 }
@@ -2094,7 +2094,7 @@ PUCHAR CCyUSBEndPoint::BeginDirectXfer(PUCHAR buf, LONG bufLen, OVERLAPPED *ov)
     if ( hDevice == INVALID_HANDLE_VALUE ) return NULL;
 
     int iXmitBufSize = sizeof (SINGLE_TRANSFER);
-    PUCHAR pXmitBuf = new UCHAR[iXmitBufSize];
+    PUCHAR pXmitBuf = (PUCHAR)ov + sizeof(OVERLAPPED);
     ZeroMemory (pXmitBuf, iXmitBufSize);
 
     PSINGLE_TRANSFER pTransfer = (PSINGLE_TRANSFER) pXmitBuf;

--- a/Core/arch/win32/FX3handler.cpp
+++ b/Core/arch/win32/FX3handler.cpp
@@ -10,6 +10,7 @@
 #include <windows.h>
 #include "FX3handler.h"
 #include "./CyAPI/CyAPI.h"
+#include "./CyAPI/cyioctl.h"
 #define RES_BIN_FIRMWARE                2000
 
 
@@ -282,6 +283,7 @@ struct ReadContext
 {
 	PUCHAR context;
 	OVERLAPPED overlap;
+	SINGLE_TRANSFER transfer;
 	uint8_t* buffer;
 	long size;
 };


### PR DESCRIPTION
This signficantly reduce USB read latency. And potentially reduce CPU usage as well.