### PR TITLE
Don't reset fx3 chip

### DIFF
--- a/Core/radio/RadioHardware.cpp
+++ b/Core/radio/RadioHardware.cpp
@@ -18,7 +18,5 @@ RadioHardware::~RadioHardware()
 {
     if (Fx3) {
         FX3SetGPIO(SHDWN);
-
-        Fx3->Control(RESETFX3);
     }
 }

--- a/Interface.h
+++ b/Interface.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#define FIRMWARE_VER_MAJOR 1
+#define FIRMWARE_VER_MINOR 2
+
 // HF103 commands !!!
 enum FX3Command {
     // Start GPII engine and stream the data from ADC

--- a/SDDC_FX3/RunApplication.c
+++ b/SDDC_FX3/RunApplication.c
@@ -39,7 +39,7 @@ CyU3PThread ThreadHandle[APP_THREADS];		// Handles to my Application Threads
 void *StackPtr[APP_THREADS];				// Stack allocated to each thread
 
 uint8_t HWconfig = NORADIO;       // Hardware config type BBRF103
-uint16_t FWconfig = 0x0102;    // Firmware rc1 ver 1.02
+uint16_t FWconfig = FIRMWARE_VER_MAJOR << 16 | FIRMWARE_VER_MINOR;    // Firmware rc1 ver 1.02
 
 CyU3PReturnStatus_t
 ConfGPIOsimpleout( uint8_t gpioid)


### PR DESCRIPTION
When disconnecting, only set the shutdown flag to stop ADC. It can make sure the device is cool. Don't reest FX3 so that we can keep the firmware in RAM. In case the firmware version mismatch, applicatio calls resetFX3 and an application restart is required.