### PR TITLE
calibration of frequency and samplerate(s) ..

### DIFF
--- a/Core/config.h
+++ b/Core/config.h
@@ -46,7 +46,7 @@ inline void null_func(const char *format, ...) { }
 
 #define VERSION             (1.1)	//	Dll version number x.xx
 #define SWVERSION           "1.1.1 alfa1"	  
-#define SETTINGS_IDENTIFIER	"sddc_1.04"
+#define SETTINGS_IDENTIFIER	"sddc_1.05"
 #define SWNAME				"ExtIO_sddc.dll"
 
 #define	QUEUE_SIZE 64

--- a/ExtIO_sddc/ExtIO_sddc.h
+++ b/ExtIO_sddc/ExtIO_sddc.h
@@ -7,36 +7,53 @@
 #endif
 
 #define _MYCONSOLE
+#define EXPORT_EXTIO_TUNE_FUNCTIONS	0
+
 
 #include "LC_ExtIO_Types.h"
 
 extern "C" bool EXTIO_API InitHW(char *name, char *model, int& type);
-extern "C" int64_t EXTIO_API StartHW64(int64_t freq);
+extern "C" int EXTIO_API StartHW64(int64_t freq);
+extern "C" int EXTIO_API StartHWdbl(double freq);
+
 extern "C" bool EXTIO_API OpenHW(void);
 extern "C" int  EXTIO_API StartHW(long freq);
+
 extern "C" void EXTIO_API StopHW(void);
 extern "C" void EXTIO_API CloseHW(void);
 //extern "C" void EXTIO_API ShowGUI();
 //extern "C" void EXTIO_API HideGUI();
 extern "C" void EXTIO_API SwitchGUI();
+
 extern "C" int  EXTIO_API SetHWLO(long LOfreq);
 extern "C" int64_t EXTIO_API SetHWLO64(int64_t LOfreq);
+extern "C" double EXTIO_API SetHWLOdbl(double LOfreq);
+
 extern "C" int  EXTIO_API GetStatus(void);
 extern "C" void EXTIO_API SetCallback(pfnExtIOCallback funcptr);
 // void extIOCallback(int cnt, int status, float IQoffs, short IQdata[]);
 
 extern "C" long EXTIO_API GetHWLO(void);
 extern "C" int64_t EXTIO_API GetHWLO64(void);
-extern "C" long EXTIO_API GetHWSR(void);
 
+extern "C" long EXTIO_API GetHWSR(void);
+extern "C" double EXTIO_API GetHWSRdbl(void);
+
+#if EXPORT_EXTIO_TUNE_FUNCTIONS
 extern "C" long EXTIO_API GetTune(void);
+extern "C" int64_t EXTIO_API GetTune64(void);
+extern "C" double EXTIO_API GetTunedbl(void);
+
+extern "C" void    EXTIO_API TuneChanged(long freq);
+extern "C" void    EXTIO_API TuneChanged64(int64_t freq);
+extern "C" void    EXTIO_API TuneChangeddbl(double freq);
+#endif
+
 // extern "C" void EXTIO_API GetFilters(int& loCut, int& hiCut, int& pitch);
 // extern "C" char EXTIO_API GetMode(void);
 // extern "C" void EXTIO_API ModeChanged(char mode);
 // extern "C" void EXTIO_API IFLimitsChanged(long low, long high);
-extern "C" void    EXTIO_API TuneChanged(long freq);
-extern "C" void    EXTIO_API TuneChanged64(int64_t freq);
-extern "C" int64_t EXTIO_API GetTune64(void);
+
 // extern "C" void    EXTIO_API IFLimitsChanged64(int64_t low, int64_t high);
 
 // extern "C" void EXTIO_API RawDataReady(long samprate, int *Ldata, int *Rdata, int numsamples);
@@ -62,8 +79,9 @@ extern "C" int EXTIO_API ExtIoGetActualMgcIdx(void);
 extern "C" int EXTIO_API ExtIoSetMGC(int mgc_idx);
 
 extern "C" int  EXTIO_API ExtIoGetSrates(int idx, double * samplerate);  // fill in possible samplerates
-extern "C" int  EXTIO_API ExtIoGetActualSrateIdx(void);               // returns -1 on error
-extern "C" int  EXTIO_API ExtIoSetSrate(int idx);                    // returns != 0 on error
+extern "C" int  EXTIO_API ExtIoSrateSelText(int idx, char* text);   // return != 0 on error
+extern "C" int  EXTIO_API ExtIoGetActualSrateIdx(void);             // returns -1 on error
+extern "C" int  EXTIO_API ExtIoSetSrate(int idx);                   // returns != 0 on error
 //extern "C" long EXTIO_API ExtIoGetBandwidth(int srate_idx);       // returns != 0 on error
 
 extern "C" int  EXTIO_API ExtIoGetSetting(int idx, char * description, char * value); // will be called (at least) before exiting application

--- a/ExtIO_sddc/extio.def
+++ b/ExtIO_sddc/extio.def
@@ -2,28 +2,40 @@ LIBRARY
 
 EXPORTS
 	InitHW
-	StartHW64
-	OpenHW
+
 	StartHW
+	StartHW64
+	StartHWdbl
+
+	OpenHW
 	StopHW
 	CloseHW
 	SwitchGUI
 	ShowGUI
 	HideGUI
+
 	SetHWLO
 	SetHWLO64
+	SetHWLOdbl
+
 	GetStatus
 	SetCallback
 
 	GetHWLO
 	GetHWLO64
+	GetHWLOdbl
+
 	GetHWSR
+	GetHWSRdbl
 
-	GetTune
+	;GetTune
+	;GetTune64
+	;GetTunedbl
 
-	TuneChanged
-	TuneChanged64
-	GetTune64
+	;TuneChanged
+	;TuneChanged64
+	;TuneChangeddbl
+
 	VersionInfo
 
 	GetAttenuators
@@ -31,6 +43,7 @@ EXPORTS
 	SetAttenuator
 
 	ExtIoGetSrates
+	ExtIoSrateSelText
 	ExtIoGetActualSrateIdx
 	ExtIoSetSrate
 

--- a/libsddc/libsddc.cpp
+++ b/libsddc/libsddc.cpp
@@ -276,7 +276,7 @@ double sddc_get_tuner_frequency(sddc_t *t)
 
 int sddc_set_tuner_frequency(sddc_t *t, double frequency)
 {
-    t->freq = t->handler->TuneLO(frequency);
+    t->freq = t->handler->TuneLO((int64_t)frequency);
 
     return 0;
 }


### PR DESCRIPTION
.. for next hdsdr release (work n progress)

* calibration setting (in registry of hdsdr) modifies reported samplerates
 see https://github.com/ik1xpv/ExtIO_sddc/issues/110
 calibration settings has to be entered manually in the registry
 Computer\HKEY_CURRENT_USER\Software\HDSDR\ExtIO_SDDC.dll\012_Value
* calibration of hdsdr can be used to determine the ppm value ..
 but it must be resetted, when entering this value in the registry
 - whilst hdsdr is already terminated
* added new extio function 'ExtIoSrateSelText()'
 to display a readable samplerate in next hdsdr release
* added double variants for several extio functions
* deactivated unnecessary extio Tune functions

Signed-off-by: hayati ayguen <h_ayguen@web.de>