### PR TITLE
Increase NDECIDX to 16

### DIFF
--- a/Core/fft_mt_r2iq.h
+++ b/Core/fft_mt_r2iq.h
@@ -35,6 +35,10 @@ private:
     int fftPerBuf; // number of ffts per buffer with 256|768 overlap
     fftwf_complex **filterHw;       // Hw complex to each decimation ratio
 
+	fftwf_plan plan_t2f_r2c;          // fftw plan buffers Freq to Time complex to complex per decimation ratio
+	fftwf_plan *plan_f2t_c2c;          // fftw plan buffers Time to Freq real to complex per buffer
+	fftwf_plan plans_f2t_c2c[NDECIDX];
+
     uint32_t processor_count;
     r2iqThreadArg* threadArgs[N_R2IQ_THREAD];
     std::condition_variable cvADCbufferAvailable;  // unlock when a sample buffer is ready

--- a/Core/r2iq.h
+++ b/Core/r2iq.h
@@ -2,7 +2,7 @@
 #define R2IQ_H
 #include "license.txt" 
 
-#define NDECIDX 7  //number of srate
+#define NDECIDX 16  //number of srate
 
 #include <thread>
 #include <mutex>
@@ -38,9 +38,9 @@ protected:
                         // 0 => 32Msps, 1=> 16Msps, 2 = 8Msps, 3 = 4Msps, 5 = 2Msps
     bool r2iqOn;        // r2iq on flag
     int16_t RandTable[65536];  // ADC RANDomize table used to whitening EMI from ADC data bus.
+    int mratio [NDECIDX];  // ratio
 
 private:
-    int mratio [NDECIDX];  // ratio
     bool randADC;       // randomized ADC output
     bool sideband;
 };


### PR DESCRIPTION
Sharing the fftw plan across the worker threads to avoid too many plans when NDECINDEX is large.
Prepare to support more sample rates.