### PR TITLE
try some ideas

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ message(STATUS "Build type: " ${CMAKE_BUILD_TYPE} " - Version: " ${VERSION} " / 
 
 if (MSVC)
     add_subdirectory(ExtIO_sddc)
-    set(CMAKE_CXX_FLAGS "-O2 /std:c++17 /EHsc /W3")
+    set(CMAKE_CXX_FLAGS "-O2 /std:c++17 /EHsc /W3 /fp:fast /Qpar /Qvec-report:2 /arch:AVX2")
 else()
     set(CMAKE_CXX_FLAGS "-O3 -std=c++17 -Wall")
     #add_compile_options(-Wall -Wextra -pedantic)

--- a/Core/fft_mt_r2iq.cpp
+++ b/Core/fft_mt_r2iq.cpp
@@ -343,6 +343,7 @@ void * fft_mt_r2iq::r2iqThreadf(r2iqThreadArg *th) {
 				th->inFreqTmp[m][1] = (source[m][1] * filter[m][0] -
 										source[m][0] * filter[m][1]);
 				}
+			}
 			if (mfft/2 != count)
 					memset(th->inFreqTmp[count], 0, sizeof(float) * 2 * (mfft/2 - count));
 
@@ -364,6 +365,7 @@ void * fft_mt_r2iq::r2iqThreadf(r2iqThreadArg *th) {
 				dest[m][1] = (source2[m][1] * filter2[m][0] -
 								source2[m][0] * filter2[m][1]);
 				}
+			}
 			if (start != 0)
 				memset(th->inFreqTmp[mfft / 2], 0, sizeof(float) * 2 * start);
 


### PR DESCRIPTION
I am trying:
1. enable auto vector of C++ compiler
2. Move int16_t -> float into the loop to improve cache usage.
3. optimize dec=0 scenario to avoid using a digit filter.
4. use a[] instead a++, which is preferred based on C++ compiler document on auto vectorize. However it still doesn't work.
