### PR TITLE
use Kaiser with 85% of Nyquist band ..

### DIFF
--- a/Core/config.h
+++ b/Core/config.h
@@ -79,8 +79,11 @@ enum rf_mode { NOMODE = 0, HFMODE = 0x1, VHFMODE = 0x2 };
 extern bool saveADCsamplesflag;
 
 const int transferSize = 131072;
+const int transferSamples = 131072 / sizeof(int16_t);
 
 const uint32_t DEFAULT_ADC_FREQ = 64000000;	// ADC sampling frequency
+
+const uint32_t DEFAULT_TRANSFERS_PER_SEC = DEFAULT_ADC_FREQ / transferSamples;
 
 #endif // _CONFIG_H_
 

--- a/Core/fft_mt_r2iq.cpp
+++ b/Core/fft_mt_r2iq.cpp
@@ -74,6 +74,24 @@ fft_mt_r2iq::fft_mt_r2iq() :
 	}
 	GainScale = BBRF103_GAINFACTOR;
 
+#ifndef NDEBUG
+	int mratio = 1;  // 1,2,4,8,16,..
+	const float Astop = 120.0f;
+	const float relPass = 0.75f;  // 85% of Nyquist should be usable
+	const float relStop = 1.2f;   // 'some' alias back into transition band is OK
+	printf("\n***************************************************************************\n");
+	printf("Filter tap estimation, Astop = %.1f dB, relPass = %.2f, relStop = %.2f\n", Astop, relPass, relStop);
+	for (int d = 0; d < NDECIDX; d++)
+	{
+		float Bw = 64.0f / mratio;
+		int ntaps = KaiserWindow(0, Astop, relPass * Bw / 128.0f, relStop * Bw / 128.0f, nullptr);
+		printf("decimation %2d: KaiserWindow(Astop = %.1f dB, Fpass = %.3f,Fstop = %.3f, Bw %.3f @ %f ) => %d taps\n",
+			d, Astop, relPass * Bw, relStop * Bw, Bw, 128.0f, ntaps);
+		mratio = mratio * 2;
+	}
+	printf("***************************************************************************\n");
+#endif
+
 }
 
 fft_mt_r2iq::~fft_mt_r2iq()

--- a/Core/fft_mt_r2iq.h
+++ b/Core/fft_mt_r2iq.h
@@ -37,6 +37,10 @@ private:
     int fftPerBuf; // number of ffts per buffer with 256|768 overlap
     fftwf_complex **filterHw;       // Hw complex to each decimation ratio
 
+	fftwf_plan plan_t2f_r2c;          // fftw plan buffers Freq to Time complex to complex per decimation ratio
+	fftwf_plan *plan_f2t_c2c;          // fftw plan buffers Time to Freq real to complex per buffer
+	fftwf_plan plans_f2t_c2c[NDECIDX];
+
     uint32_t processor_count;
     r2iqThreadArg* threadArgs[N_MAX_R2IQ_THREADS];
     std::condition_variable cvADCbufferAvailable;  // unlock when a sample buffer is ready

--- a/Core/fir.h
+++ b/Core/fir.h
@@ -1,3 +1,3 @@
 #pragma once
 
-void KaiserWindow(int num_taps, float Astop, float normFpass, float normFstop, float *m_Coef);
+int KaiserWindow(int num_taps, float Astop, float normFpass, float normFstop, float * Coef);

--- a/Core/r2iq.h
+++ b/Core/r2iq.h
@@ -2,7 +2,7 @@
 #define R2IQ_H
 #include "license.txt" 
 
-#define NDECIDX 16  //number of srate
+#define NDECIDX 10  //number of srate
 
 #include <thread>
 #include <mutex>

--- a/Core/r2iq.h
+++ b/Core/r2iq.h
@@ -2,7 +2,7 @@
 #define R2IQ_H
 #include "license.txt" 
 
-#define NDECIDX 7  //number of srate
+#define NDECIDX 16  //number of srate
 
 #include <thread>
 #include <mutex>
@@ -39,9 +39,9 @@ protected:
       // 128 Msps: 0 => 64Msps, 1 => 32Msps, 2=> 16Msps, 3 = 8Msps, 4 = 4Msps, 5 = 2Msps
     bool r2iqOn;        // r2iq on flag
     int16_t RandTable[65536];  // ADC RANDomize table used to whitening EMI from ADC data bus.
+    int mratio [NDECIDX];  // ratio
 
 private:
-    int mratio [NDECIDX];  // ratio
     bool randADC;       // randomized ADC output
     bool sideband;
 };


### PR DESCRIPTION
looked into the received spectrum with HDSDR, whilst generating the input (single carrier) with a 'cheap' signal/DDS generator.
the results don't look as expected.
i would suggest to generate and test the decimation core in a unittest - as in 'pipeline dsp' https://github.com/ik1xpv/ExtIO_sddc/pull/135 , to check if unwanted spurs/carrier are produced by software-error - or not
