### PR TITLE
fix: add dependency on LIBCPPUNIT in unittest/CMakeLists.txt

### DIFF
--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -15,6 +15,7 @@ SET(LIBCPPUNIT_INCLUDE_DIRS ${SOURCE_DIR})
 file(GLOB UNITTESTS "./*.cpp")
 
 add_executable(unittest ${UNITTESTS})
+add_dependencies(unittest LIBCPPUNIT)
 
 target_include_directories(unittest PUBLIC "${LIBFFTW_INCLUDE_DIR}")
 target_link_directories(unittest PUBLIC "${LIBFFTW_LIBRARY_DIRS}")


### PR DESCRIPTION
Add a dependency on LIBCPPUNIT in unittest/CMakeLists.txt otherwise the build on my computer (Linux Fedora 33) fails with this error:

```
[ 69%] Building CXX object unittest/CMakeFiles/unittest.dir/core_test.cpp.o
/tmp/ExtIO_sddc/unittest/core_test.cpp:3:10: fatal error: CppUnitTestFramework.hpp: No such file or directory
    3 | #include "CppUnitTestFramework.hpp"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [unittest/CMakeFiles/unittest.dir/build.make:82: unittest/CMakeFiles/unittest.dir/core_test.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1082: unittest/CMakeFiles/unittest.dir/all] Error 2
```

Thanks,
Franco