### PR TITLE
Reference PPM calibration by HDSDR

### DIFF
--- a/ExtIO_sddc/ExtIO_sddc.cpp
+++ b/ExtIO_sddc/ExtIO_sddc.cpp
@@ -111,24 +111,7 @@ bool __declspec(dllexport) __stdcall InitHW(char *name, char *model, int& type)
 	type = gHwType;
 	if (!gbInitHW)
 	{
-		// do initialization
-		// verify if HDSDR host name 
-		GetModuleFileName(NULL, SDR_progname, sizeof(SDR_progname) - 1);
-		if (strstr(SDR_progname, "HDSDR") == nullptr)
-		{
-			bSupportDynamicSRate = false;
-			h_dialog = CreateDialog(hInst, MAKEINTRESOURCE(IDD_DLG_MAIN), NULL, (DLGPROC)&DlgMainFn);
-		}
-		else
-		{
-			bSupportDynamicSRate = true;
-			h_dialog = CreateDialog(hInst, MAKEINTRESOURCE(IDD_DLG_HDSDR), NULL, (DLGPROC)&DlgMainFn);
-		}
-		RECT rect;
-		GetWindowRect(h_dialog, &rect);
-		SetWindowPos(h_dialog, HWND_TOPMOST, 0, 24, rect.right - rect.left, rect.bottom - rect.top, SWP_HIDEWINDOW);
 		splashW.createSplashWindow(hInst, IDB_BITMAP2, 15, 15, 15);
-
 #ifdef _DEBUG
 		if (AllocConsole())
 		{
@@ -211,17 +194,28 @@ bool EXTIO_API OpenHW(void)
 
 	// .... display here the DLL panel ,if any....
 
-//    ShowWindow(h_dialog, SW_SHOW);
-//     ShowWindow(h_dialog, SW_HIDE);
 #ifndef _DEBUG
 	splashW.showWindow();
 #endif
 
-	//EXTIO_STATUS_CHANGE(pfnCallback, extHw_Changed_ATT);
 
 	splashW.destroySplashWindow();
-
-	SetWindowPos(h_dialog, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+	// do initialization
+//   verify if HDSDR host name 
+	if (strstr(SDR_progname, "HDSDR") == nullptr)
+	{
+		h_dialog = CreateDialog(hInst, MAKEINTRESOURCE(IDD_DLG_MAIN), NULL, (DLGPROC)&DlgMainFn);
+	}
+	else
+	{
+		if (( SDR_ver_major >= 2) && (SDR_ver_minor >=81))
+			h_dialog = CreateDialog(hInst, MAKEINTRESOURCE(IDD_DLG_HDSDR281), NULL, (DLGPROC)&DlgMainFn);
+		else
+			h_dialog = CreateDialog(hInst, MAKEINTRESOURCE(IDD_DLG_HDSDR), NULL, (DLGPROC)&DlgMainFn);
+	}
+	RECT rect;
+	GetWindowRect(h_dialog, &rect);
+	SetWindowPos(h_dialog, HWND_TOPMOST, 0, 24, rect.right - rect.left, rect.bottom - rect.top, SWP_HIDEWINDOW);
 
 	// in the above statement, F->handle is the window handle of the panel displayed
 	// by the DLL, if such a panel exists

--- a/ExtIO_sddc/ExtIO_sddc.cpp
+++ b/ExtIO_sddc/ExtIO_sddc.cpp
@@ -805,6 +805,17 @@ void EXTIO_API SetPPMvalue(double new_ppm_value)
 {
 	gfFreqCorrectionPpm = new_ppm_value;
 	SetOverclock(adcnominalfreq);
+	char lbuffer[64];
+	sprintf(lbuffer, "%3.2f", gfFreqCorrectionPpm);
+	SetWindowText(GetDlgItem(h_dialog, IDC_EDIT2), lbuffer);
+}
+
+//---------------------------------------------------------------------------
+// will be called by HDSDR with reference correction in ppm
+extern "C"
+double EXTIO_API GetPPMvalue(void)
+{
+	return gfFreqCorrectionPpm;
 }
 
 //---------------------------------------------------------------------------

--- a/ExtIO_sddc/ExtIO_sddc.cpp
+++ b/ExtIO_sddc/ExtIO_sddc.cpp
@@ -805,9 +805,7 @@ void EXTIO_API SetPPMvalue(double new_ppm_value)
 {
 	gfFreqCorrectionPpm = new_ppm_value;
 	SetOverclock(adcnominalfreq);
-	char lbuffer[64];
-	sprintf(lbuffer, "%3.2f", gfFreqCorrectionPpm);
-	SetWindowText(GetDlgItem(h_dialog, IDC_EDIT2), lbuffer);
+	UpdatePPM(h_dialog);  // update dialog PPM
 }
 
 //---------------------------------------------------------------------------

--- a/ExtIO_sddc/ExtIO_sddc.h
+++ b/ExtIO_sddc/ExtIO_sddc.h
@@ -87,5 +87,6 @@ extern "C" int  EXTIO_API ExtIoSetSrate(int idx);                   // returns !
 extern "C" int  EXTIO_API ExtIoGetSetting(int idx, char * description, char * value); // will be called (at least) before exiting application
 extern "C" void EXTIO_API ExtIoSetSetting(int idx, const char * value); // before calling InitHW() !!!
 
-extern "C" void EXTIO_API SetPPMvalue(double new_ppm_value);   
+extern "C" void EXTIO_API SetPPMvalue(double new_ppm_value);  
+extern "C" double EXTIO_API GetPPMvalue(void);
 extern "C" void EXTIO_API IFrateInfo(int rate);  

--- a/ExtIO_sddc/extio.def
+++ b/ExtIO_sddc/extio.def
@@ -48,7 +48,7 @@ EXPORTS
 	ExtIoSetSrate
 
     SetPPMvalue
-
+	GetPPMvalue
 
 	ExtIoGetSetting
 	ExtIoSetSetting

--- a/ExtIO_sddc/resource.h
+++ b/ExtIO_sddc/resource.h
@@ -8,6 +8,7 @@
 #define IDB_BITMAP1                     105
 #define IDB_BITMAP2                     106
 #define IDD_DLG_HDSDR                   107
+#define IDD_DLG_HDSDR281                108
 #define DIALOGH                         80
 #define IDC_LW                          1001
 #define IDC_HF                          1002

--- a/ExtIO_sddc/resource.rc
+++ b/ExtIO_sddc/resource.rc
@@ -116,10 +116,50 @@ BEGIN
     LTEXT           "IQ:", IDC_STATIC, 151, 108, 17, 10
     CTEXT           "64.0Msps", IDC_STATIC16, 165, 108, 45, 10, WS_BORDER
 
-    GROUPBOX        "", IDC_STATIC, 1, 82, 215, 1
+    GROUPBOX        "", IDC_STATIC, 1, 82, 215, 2
     LTEXT           "Debug mode active", IDC_STATIC, 2, 90, 80, 10, NOT WS_GROUP
     CONTROL         "128M", IDC_OVERCLOCK, "Button", BS_AUTOCHECKBOX | WS_TABSTOP, 100, 90, 28, 10
     PUSHBUTTON      "Save ADC", IDC_ADCSAMPLES, 150, 90, 48, 13, BS_FLAT
+
+
+END
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Dialog used with HDSDR host >2.81
+//
+
+IDD_DLG_HDSDR281 DIALOGEX 0, 0, 216, (DIALOGH - 20)  // dimensions release
+STYLE DS_SETFONT | WS_CAPTION | WS_SYSMENU
+CAPTION "ExtIO_sddc.dll ver:1.4"
+FONT 8, "Ms Shell Dlg", 0, 0, 0x0
+BEGIN
+GROUPBOX        "", IDC_STATIC, 4, 1, 208, 23
+LTEXT           "Antenna BiasT 3.3 Volt", IDC_STATIC, 16, 10, 80, 10, NOT WS_GROUP
+CONTROL         "VHF", IDC_BIAS_VHF, "Button", BS_AUTOCHECKBOX | WS_TABSTOP, 100, 10, 25, 10
+CONTROL         "HF", IDC_BIAS_HF, "Button", BS_AUTOCHECKBOX | WS_TABSTOP, 150, 10, 25, 10
+
+GROUPBOX        "", IDC_STATIC, 4, 19, 208, 40
+LTEXT           "ADC", IDC_STATIC, 16, 28, 17, 10, NOT WS_GROUP
+CONTROL         "Dither", IDC_DITHER, "Button", BS_AUTOCHECKBOX | WS_TABSTOP, 100, 27, 30, 10
+CONTROL         "Rand", IDC_RAND, "Button", BS_AUTOCHECKBOX | WS_TABSTOP, 150, 27, 30, 10
+LTEXT	        "Sampling frequency  Hz" IDC_STATIC, 16, 44, 100, 10, NOT WS_GROUP
+EDITTEXT        IDC_EDIT1, 100, 42, 46, 13, ES_CENTER | ES_UPPERCASE |
+ES_AUTOHSCROLL | ES_NUMBER
+PUSHBUTTON      "Apply", IDC_FREQAPPLY, 150, 42, 27, 12, WS_GROUP | NOT WS_TABSTOP
+PUSHBUTTON      "Cancel", IDC_FREQCANC, 178, 42, 27, 12, WS_GROUP | NOT WS_TABSTOP
+
+LTEXT           "ADC:", IDC_STATIC, 2, 88, 22, 10
+CTEXT           "128.0Msps", IDC_STATIC13, 23, 88, 38, 10, WS_BORDER
+LTEXT           "USB:", IDC_STATIC, 75, 88, 21, 10
+CTEXT           "256.0Mbps", IDC_STATIC14, 96, 88, 41, 10, WS_BORDER
+LTEXT           "IQ:", IDC_STATIC, 151, 88, 17, 10
+CTEXT           "64.0Msps", IDC_STATIC16, 165, 88, 45, 10, WS_BORDER
+
+GROUPBOX        "", IDC_STATIC, 1, 64, 215, 2
+LTEXT           "Debug mode active", IDC_STATIC, 2, 70, 60, 10, NOT WS_GROUP
+CONTROL         "128M", IDC_OVERCLOCK, "Button", BS_AUTOCHECKBOX | WS_TABSTOP, 100, 70, 28, 10
+PUSHBUTTON      "Save ADC", IDC_ADCSAMPLES, 150, 70, 48, 13, BS_FLAT
 
 
 END

--- a/ExtIO_sddc/tdialog.cpp
+++ b/ExtIO_sddc/tdialog.cpp
@@ -30,6 +30,12 @@ extern RadioHandlerClass RadioHandler;
 extern "C" int SetOverclock(uint32_t adcfreq);
 extern double	gfFreqCorrectionPpm;
 
+void UpdatePPM(HWND hWnd)
+{
+	char lbuffer[64];
+	sprintf(lbuffer, "%3.2f", gfFreqCorrectionPpm);
+	SetWindowText(GetDlgItem(hWnd, IDC_EDIT2), lbuffer);
+}
 
 void UpdateGain(HWND hControl, int current, const float* gains, int length)
 {
@@ -109,9 +115,7 @@ BOOL CALLBACK DlgMainFn(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 		char lbuffer[64];
 		sprintf(lbuffer, "%d", adcnominalfreq);
 		SetWindowText(GetDlgItem(hWnd, IDC_EDIT1), lbuffer);
-		sprintf(lbuffer, "%3.2f", gfFreqCorrectionPpm);
-		SetWindowText(GetDlgItem(hWnd, IDC_EDIT2), lbuffer);
-
+		UpdatePPM(hWnd);  // update dialog PPM
 		SetTimer(hWnd, 0, 200, NULL);
 	}
 	return TRUE;

--- a/ExtIO_sddc/tdialog.h
+++ b/ExtIO_sddc/tdialog.h
@@ -8,6 +8,7 @@
 #include <stdio.h>
 
 extern bool bSupportDynamicSRate;
+extern void UpdatePPM(HWND hWnd);
 
 BOOL CALLBACK DlgMainFn(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 


### PR DESCRIPTION
Now the reference calibration in ppm may be done via HDSDR GUI calibration.
The function GetPPMvalue() is added.
![CalibrationPPM](https://user-images.githubusercontent.com/9883800/109173249-ee750680-7783-11eb-8a0f-a2cd5a4f4b0d.jpg)
