### PR TITLE
Allow toggle bias-t in SoapySDDC

### DIFF
--- a/SoapySDDC/Settings.cpp
+++ b/SoapySDDC/Settings.cpp
@@ -391,25 +391,16 @@ SoapySDR::ArgInfoList SoapySDDC::getSettingInfo(void) const
 
 void SoapySDDC::writeSetting(const std::string &key, const std::string &value)
 {
+    bool biasTee;
     if (key == "UpdBiasT_HF")
     {
-        bool biast;
-        if (value == "false") {
-            biast = false;
-        } else {
-            biast = true;
-        }
-        RadioHandler.UpdBiasT_HF(biast);
+        biasTee = (value == "true") ? true: false;
+        RadioHandler.UpdBiasT_HF(biasTee);
     }
     else if (key == "UpdBiasT_VHF")
     {
-        bool biast;
-        if (value == "false") {
-            biast = false;
-        } else {
-            biast = true;
-        }
-        RadioHandler.UpdBiasT_VHF(biast);
+        biasTee = (value == "true") ? true: false;
+        RadioHandler.UpdBiasT_VHF(biasTee);
     }
 }
 

--- a/SoapySDDC/Settings.cpp
+++ b/SoapySDDC/Settings.cpp
@@ -132,12 +132,10 @@ void SoapySDDC::setAntenna(const int direction, const size_t, const std::string 
     if (name == "HF")
     {
         RadioHandler.UpdatemodeRF(HFMODE);
-        RadioHandler.UpdBiasT_HF(true);
     }
     else if (name == "VHF")
     {
         RadioHandler.UpdatemodeRF(VHFMODE);
-        RadioHandler.UpdBiasT_VHF(true);
     }
     else
     {
@@ -367,6 +365,54 @@ std::vector<double> SoapySDDC::listSampleRates(const int, const size_t) const
 
     return results;
 }
+
+SoapySDR::ArgInfoList SoapySDDC::getSettingInfo(void) const
+{
+    SoapySDR::ArgInfoList setArgs;
+
+    SoapySDR::ArgInfo BiasTHFArg;
+    BiasTHFArg.key = "UpdBiasT_HF";
+    BiasTHFArg.value = "false";
+    BiasTHFArg.name = "HF Bias Tee enable";
+    BiasTHFArg.description = "Enabe Bias Tee on HF antenna port";
+    BiasTHFArg.type = SoapySDR::ArgInfo::BOOL;
+    setArgs.push_back(BiasTHFArg);
+
+    SoapySDR::ArgInfo BiasTVHFArg;
+    BiasTVHFArg.key = "UpdBiasT_VHF";
+    BiasTVHFArg.value = "false";
+    BiasTVHFArg.name = "VHF Bias Tee enable";
+    BiasTVHFArg.description = "Enabe Bias Tee on VHF antenna port";
+    BiasTVHFArg.type = SoapySDR::ArgInfo::BOOL;
+    setArgs.push_back(BiasTVHFArg);
+
+    return setArgs;
+}
+
+void SoapySDDC::writeSetting(const std::string &key, const std::string &value)
+{
+    if (key == "UpdBiasT_HF")
+    {
+        bool biast;
+        if (value == "false") {
+            biast = false;
+        } else {
+            biast = true;
+        }
+        RadioHandler.UpdBiasT_HF(biast);
+    }
+    else if (key == "UpdBiasT_VHF")
+    {
+        bool biast;
+        if (value == "false") {
+            biast = false;
+        } else {
+            biast = true;
+        }
+        RadioHandler.UpdBiasT_VHF(biast);
+    }
+}
+
 
 // void SoapySDDC::setMasterClockRate(const double rate)
 // {

--- a/SoapySDDC/SoapySDDC.hpp
+++ b/SoapySDDC/SoapySDDC.hpp
@@ -107,6 +107,10 @@ public:
 
     std::vector<double> listSampleRates(const int direction, const size_t channel) const;
 
+    SoapySDR::ArgInfoList getSettingInfo(void) const;
+
+    void writeSetting(const std::string &key, const std::string &value);
+
     // void setMasterClockRate(const double rate);
 
     // double getMasterClockRate(void) const;


### PR DESCRIPTION
I’ve tested the Bias-T toggle function with a voltmeter and confirmed that it works on the RX-888 MKII. However, I haven’t tested it on earlier generations of the hardware.