### PR TITLE
fix: Solve build errors for the platform `linux/arm64`

### DIFF
--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -20,7 +20,7 @@ else()
     set_source_files_properties(fft_mt_r2iq_avx.cpp PROPERTIES COMPILE_FLAGS -mavx)
     set_source_files_properties(fft_mt_r2iq_avx2.cpp PROPERTIES COMPILE_FLAGS -mavx2)
     set_source_files_properties(fft_mt_r2iq_avx512.cpp PROPERTIES COMPILE_FLAGS -mavx512f)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "arm.*")
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "arm.*" OR "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64")
     # We may have Neon..
     message(STATUS "Compiling for Neon")
     list(FILTER SRC EXCLUDE REGEX "fft_mt_r2iq_avx.*")

--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -25,9 +25,9 @@ else()
     message(STATUS "Compiling for Neon")
     list(FILTER SRC EXCLUDE REGEX "fft_mt_r2iq_avx.*")
     list(APPEND SRC fft_mt_r2iq_neon.cpp)
-    # On Apple Silicon (arm64) clang does not accept '-mfpu='; NEON is enabled by default.
-    if(APPLE)
-      # Don't pass -mfpu to Apple clang; only enable PFFFT's NEON code path and relax strict-aliasing warnings
+    # On aarch64 (including Apple Silicon), NEON/ASIMD is always available and
+    # '-mfpu=' is not accepted.  Only pass '-mfpu=neon-vfpv4' for 32-bit ARM.
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64" OR APPLE)
       set_source_files_properties(fft_mt_r2iq_neon.cpp PROPERTIES COMPILE_FLAGS "")
       set_source_files_properties(pffft/pf_mixer.cpp PROPERTIES COMPILE_FLAGS "-D PFFFT_ENABLE_NEON -Wno-strict-aliasing")
     else()

--- a/Core/fft_mt_r2iq.cpp
+++ b/Core/fft_mt_r2iq.cpp
@@ -235,7 +235,11 @@ void fft_mt_r2iq::Init(float gain, ringbuffer<int16_t> *input, ringbuffer<float>
 	static bool detect_neon()
 	{
 		unsigned long caps = getauxval(AT_HWCAP);
+	#if defined(__aarch64__)
+		return (caps & HWCAP_ASIMD);
+	#else
 		return (caps & HWCAP_NEON);
+	#endif
 	}
     #elif defined(__APPLE__)
         #include <sys/sysctl.h>


### PR DESCRIPTION
See [issue-243](https://github.com/ik1xpv/ExtIO_sddc/issues/243), the patch in this PR is provided by Claude Opus 4.6.