### PR TITLE
fix: Provide support for the platform linux/arm64

### DIFF
--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -20,14 +20,14 @@ else()
     set_source_files_properties(fft_mt_r2iq_avx.cpp PROPERTIES COMPILE_FLAGS -mavx)
     set_source_files_properties(fft_mt_r2iq_avx2.cpp PROPERTIES COMPILE_FLAGS -mavx2)
     set_source_files_properties(fft_mt_r2iq_avx512.cpp PROPERTIES COMPILE_FLAGS -mavx512f)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "arm.*")
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "arm.*|aarch64")
     # We may have Neon..
     message(STATUS "Compiling for Neon")
     list(FILTER SRC EXCLUDE REGEX "fft_mt_r2iq_avx.*")
     list(APPEND SRC fft_mt_r2iq_neon.cpp)
-    # On Apple Silicon (arm64) clang does not accept '-mfpu='; NEON is enabled by default.
-    if(APPLE)
-      # Don't pass -mfpu to Apple clang; only enable PFFFT's NEON code path and relax strict-aliasing warnings
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64" OR APPLE)
+      # On aarch64 (including Apple Silicon), NEON is always available and '-mfpu=' is not accepted.
+      # Only enable PFFFT's NEON code path and relax strict-aliasing warnings
       set_source_files_properties(fft_mt_r2iq_neon.cpp PROPERTIES COMPILE_FLAGS "")
       set_source_files_properties(pffft/pf_mixer.cpp PROPERTIES COMPILE_FLAGS "-D PFFFT_ENABLE_NEON -Wno-strict-aliasing")
     else()

--- a/Core/fft_mt_r2iq.cpp
+++ b/Core/fft_mt_r2iq.cpp
@@ -234,8 +234,13 @@ void fft_mt_r2iq::Init(float gain, ringbuffer<int16_t> *input, ringbuffer<float>
 	#include <asm/hwcap.h>
 	static bool detect_neon()
 	{
+	#if defined(__aarch64__)
+		// NEON is always available
+		return true;
+	#else
 		unsigned long caps = getauxval(AT_HWCAP);
 		return (caps & HWCAP_NEON);
+	#endif
 	}
     #elif defined(__APPLE__)
         #include <sys/sysctl.h>


### PR DESCRIPTION
> [The last PR](https://github.com/ik1xpv/ExtIO_sddc/pull/246) got polluted with some other commits. This fresh PR includes only the original changes.

Solve build errors when building from source on the platform `linux/arm64`. Validated using this `Dockerfile` (placed in the root directory of the project):

```Dockerfile
FROM ubuntu:22.04 AS base

RUN apt-get update && apt-get install -y \
    libusb-1.0 \
    libfftw3-dev \
    libsoapysdr-dev

FROM base AS build

RUN apt-get update && apt-get install -y \
    git \
    cmake \
    build-essential \
    pkg-config

WORKDIR /tmp

COPY . ExtIO_sddc/

RUN cd ExtIO_sddc && \
    mkdir build && \
    cd build && \
    cmake .. -DCMAKE_INSTALL_PREFIX=/opt/ExtIO_sddc && \
    make && \
    make install && \
    mkdir -p /opt/ExtIO_sddc/bin && \
    cp unittest/unittest /opt/ExtIO_sddc/bin/unittest

FROM base AS runtime

COPY --from=build /opt/ExtIO_sddc/bin/unittest /usr/local/bin/unittest

CMD ["unittest"]
```

To build an image:   

```bash
docker buildx build --platform linux/arm64 --tag extio_sddc:mre --target runtime . --load
```

And running a container from it:  

```bash
docker run --platform linux/arm64  extio_sddc:mre
Running 9 test cases...
decimate=0 nxfers=201 count=8 totalsize=262144
decimate=1 nxfers=195 count=16 totalsize=524288
decimate=2 nxfers=181 count=27 totalsize=884736
decimate=3 nxfers=160 count=46 totalsize=1507328
decimate=4 nxfers=135 count=69 totalsize=2260992
Complete.
    Passed:  9
    Failed:  0
    Skipped: 0
```

In the same way, the build and unit tests succeed using the platform `linux/amd64`. 